### PR TITLE
feat: add sqlc configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Notes:
 
 ## Stack
 
-This repository uses [go-chi](https://github.com/go-chi/chi) as a router. I prefer keeping stuff simple and close to the metal.
+This repository uses [go-chi](https://github.com/go-chi/chi) as a router, it uses [sqlc](https://sqlc.dev/) for the DAL and PGX as the DB driver
+for Postgres.
 
 ## Setup
 
@@ -30,3 +31,8 @@ We use pre-commit to orchestrate linting.
 There is a `dockerfile` in the repository root which uses `distroless` as the production image. Use docker compose for local development:
 
 - `docker compose up --build`
+
+### SQLC
+
+1. [sqlc](https://sqlc.dev/).
+2. run `sqlc generate` or any of the other commands in the root.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,22 @@ services:
     image: redis:latest
     ports:
       - "6379:6379"
+  db:
+    image: postgres:latest
+    volumes:
+      - db:/var/lib/postrgresql/data/
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: monorepo
+      POSTGRES_DB: monorepo
+      POSTGRES_USER: monorepo
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U monorepo"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
   auth:
     build:
       dockerfile: Dockerfile
@@ -20,3 +36,7 @@ services:
       ENVIRONMENT: development
       BASE_URL: http://localhost:3000
       REDIS_CONNECTION_STRING: redis://redis:6379
+      DATABASE_URL: postgresql://monorepo:monorepo@db:5432/monorepo
+
+volumes:
+  db:

--- a/sql/query.sql
+++ b/sql/query.sql
@@ -1,0 +1,15 @@
+-- name: UpsertUser :one
+INSERT INTO "user" (display_name, email, phone_number, photo_url, provider_id)
+VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (email)
+    DO UPDATE SET display_name = $2,
+                  phone_number = $4,
+                  photo_url    = $5,
+                  provider_id  = $6
+RETURNING "user".id;
+
+-- name: GetUserById :one
+SELECT *
+FROM "user"
+WHERE id = $1
+LIMIT 1;

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,13 @@
+-- user
+CREATE TABLE "user"
+(
+    id                  uuid PRIMARY KEY      DEFAULT gen_random_uuid(),
+    firebase_id         varchar(128) NOT NULL,
+    full_name           text         NOT NULL,
+    email               text         NOT NULL,
+    phone_number        varchar(128) NOT NULL,
+    profile_picture_url text         NOT NULL,
+    username            text         NOT NULL,
+    hashed_password     text         NOT NULL,
+    created_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -1,0 +1,13 @@
+version: "2"
+sql:
+  - engine: "postgresql"
+    queries: "./sql/query.sql"
+    schema: "./sql/schema.sql"
+    database:
+      uri: ${DATABASE_URL}
+    gen:
+      go:
+        package: "db"
+        out: "db"
+        sql_package: "pgx/v5"
+        emit_json_tags: true


### PR DESCRIPTION
This PR adds SQLC configs, but doesn't add the connection to the app layer itself, nor does it generate the code from SQL. 

Followups:

1. finalize the `schema.sql` so it is aligned with the providers for oauth and works with whatever we need for password/username auth as well.
2. generate code by installing sqlc and running `sqlc generate`.
3. connect the DB layer to the application.